### PR TITLE
Fixes to forge.sh

### DIFF
--- a/runners/forge.sh
+++ b/runners/forge.sh
@@ -1,7 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+CURRENT_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 OS=${OS:-"unknown"}
-function run() {
+run() {
   if [[ "$OS" != "Windows_NT" ]]
   then
     mono "$@"
@@ -10,4 +18,4 @@ function run() {
   fi
 }
 
-run bin/forge.exe "$@"
+run "${CURRENT_DIR}/bin/forge.exe" "$@"

--- a/runners/forge.sh
+++ b/runners/forge.sh
@@ -18,4 +18,4 @@ run() {
   fi
 }
 
-run "${CURRENT_DIR}/bin/forge.exe" "$@"
+run "${CURRENT_DIR}/bin/Forge.exe" "$@"


### PR DESCRIPTION
This PR allows `forge.sh` to be run from any directory (not just from within the build output dir), and fixes a case-sensitivity issue (`bin/Forge.exe` vs `bin/forge.exe`) that was breaking `forge.sh` on case-sensitive filesystems (like Linux).

The "any-directory" piece does rely on a Bashism, which means that FreeBSD users will need to install bash -- but it will work out of the box on OSX and Linux.