### PR TITLE
Patch to make normalizeFileName behave on Linux/OSX

### DIFF
--- a/src/Forge.Core/ProjectSystem.fs
+++ b/src/Forge.Core/ProjectSystem.fs
@@ -383,7 +383,9 @@ type SourceElement =
 module internal PathHelpers =
 
     let normalizeFileName (fileName : string) =
-        let file = fileName.Replace(@"\", "/").TrimEnd(Path.DirectorySeparatorChar).ToLower()
+        let file = if (fileName = (Path.DirectorySeparatorChar |> string)) 
+                   then fileName
+                   else fileName.Replace(@"\", "/").TrimEnd(Path.DirectorySeparatorChar).ToLower()
         match file with
         | "/" -> "/"
         | f -> f.TrimStart '/'

--- a/tests/Forge.Tests/ProjectSystemTest.fs
+++ b/tests/Forge.Tests/ProjectSystemTest.fs
@@ -12,6 +12,7 @@ open FsUnit
 [<Test>]
 let ``ProjectSystem parse - AST gets all project files`` () =
     let projectFile = FsProject.parse astInput
+    System.Diagnostics.Debug.WriteLine projectFile
     projectFile.SourceFiles.AllFiles() |> Seq.length |> should be (equal 3)
 
 


### PR DESCRIPTION
On Linux/OSX, `Path.DirectorySeparatorChar` is `/`, so running `normalizeFileName "/"` will spit you back out `""`.

Another possibility here is instead of treating the project base directory as `"/"`, use `"./"` (as is common on Linux/OSX). That way, you'd be doing `normalizeFileName "./"`, which would give you `"."`, which means "current/base directory".