### PR TITLE
Minor fixes

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -82,7 +82,7 @@ Target "AssemblyInfo" (fun _ ->
           (getAssemblyInfoAttributes projectName)
         )
 
-    !! "src/**/*.??proj"
+    !! "src/**/*.??proj" -- "src/**/templates/**/*.*"
     |> Seq.map getProjectDetails
     |> Seq.iter (fun (projFileName, projectName, folderName, attributes) ->
         match projFileName with

--- a/src/Forge.Core/ProjectSystem.fs
+++ b/src/Forge.Core/ProjectSystem.fs
@@ -210,6 +210,9 @@ type WarningLevel (x:int) =
     member __.Value =
         if x < 0 then 0 elif x > 5 then 5 else x
 
+    override self.ToString() = 
+        self.Value.ToString()
+
 
 let inline toXElem x = (^a:(member ToXElem:unit->'b) x)
 


### PR DESCRIPTION
2 small fixes:
1. When converting`ConfigSettings` to XML (e.g. when saving project state after adding a new file), `WarningLevel` property is saved as `"Forge.ProjectSystem+WarningLevel"` string, not as an integer, so I've added `ToString()` overload to `WarningLevel` structure to fix that.
2. Ignore project files located in `templates` folder when building Forge via `build.fsx`. For example, there might be Service Fabric project files that are not supported by the build script.