### PR TITLE
Rename folder (fix for #65)

### DIFF
--- a/src/Forge.Core/ProjectManager.fs
+++ b/src/Forge.Core/ProjectManager.fs
@@ -190,13 +190,15 @@ module Furnace =
     let renameDirectory (path:string, newName:string) (state: ActiveState) =
         let fullOldPath = state.ProjectPath </> path
         let fullNewPath = state.ProjectPath </> newName
-
-        if not ^ directoryExists fullOldPath then
-            traceError ^ sprintf "Cannot Rename Directory - '%s' does not exist" fullOldPath
-            state
-        else
+        
+        // TODO Add method that checks if directory exists and returns 
+        // it's type: real or virtual (with linked files)
+        let state' = updateProj (FsProject.renameDir path newName) state
+        
+        if directoryExists fullOldPath then
             renameDir fullNewPath fullOldPath
-            updateProj (FsProject.renameDir path newName)  state
+            
+        state'
 
     let renameSourceFile (path:string, newName:string) (state: ActiveState) =
         if not ^ File.Exists path then

--- a/src/Forge.Core/ProjectManager.fs
+++ b/src/Forge.Core/ProjectManager.fs
@@ -188,13 +188,15 @@ module Furnace =
 
 
     let renameDirectory (path:string, newName:string) (state: ActiveState) =
-        if not ^ directoryExists path then
-            traceError ^ sprintf "Cannot Rename Directory - '%s' does not exist" path
+        let fullOldPath = state.ProjectPath </> path
+        let fullNewPath = state.ProjectPath </> newName
+
+        if not ^ directoryExists fullOldPath then
+            traceError ^ sprintf "Cannot Rename Directory - '%s' does not exist" fullOldPath
             state
         else
-            renameDir path newName
+            renameDir fullNewPath fullOldPath
             updateProj (FsProject.renameDir path newName)  state
-            
 
     let renameSourceFile (path:string, newName:string) (state: ActiveState) =
         if not ^ File.Exists path then

--- a/tests/Forge.Tests/common.fs
+++ b/tests/Forge.Tests/common.fs
@@ -2,6 +2,7 @@ module Forge.Tests.Common
 open Forge
 
 open NUnit.Framework
+open NUnit.Framework.Constraints
 
 
 
@@ -15,6 +16,8 @@ let shouldbetext expected actual =
     let cleanupActual = cleanup actual
 
     Assert.AreEqual(cleanupExpected, cleanupActual)
+
+let equivalent (x: seq<_>) = CollectionEquivalentConstraint x
 
 let astInput =
     """<?xml version="1.0" encoding="utf-8"?>
@@ -78,6 +81,32 @@ let projectWithFiles = """<?xml version="1.0" encoding="utf-8"?>
             <Compile Include="FixProject.fs" />
             <None Include="App.config" />
             <Compile Include="a_file.fs" />
+        </ItemGroup>
+    </Project>
+    """
+
+let projectWithLinkedFiles = """<?xml version="1.0" encoding="utf-8"?>
+    <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+        <ItemGroup>
+            <Reference Include="mscorlib" />
+            <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+              <Private>True</Private>
+            </Reference>
+            <Reference Include="System" />
+            <Reference Include="System.Core" />
+            <Reference Include="System.Numerics" />
+        </ItemGroup>
+        <ItemGroup>
+            <Compile Include="FixProject.fs" />
+            <None Include="App.config" />
+            <Compile Include="a_file.fs" />
+            <Compile Include="foo/bar/some-file.fs" />
+            <Compile Include="foo/bar/some-file2.fs" />
+            <Compile Include="foo/abc/some-file3.fs" />
+            <Compile Include="fldr/some-file2.fs" />
+            <Compile Include="../foo/external.fs">
+                <Link>linked/ext/external.fs</Link>
+            </Compile>
         </ItemGroup>
     </Project>
     """


### PR DESCRIPTION
This PR adds functionality that allows to rename folders in projects (both physical and virtual folders with linked files that don't exist on disk)

- [x] Rename folders that exist on disk
- [x] Rename virtual folders that contain linked files
- [x] Tests for projects folders renaming

Regarding renaming of solution folders, I guess it will be easier to implement it after solution file parsing is done.