### PR TITLE
Fixed failure to handle spaces or other special characters when running mono exes.

### DIFF
--- a/src/Forge.Core/ProcessHelper.fs
+++ b/src/Forge.Core/ProcessHelper.fs
@@ -47,7 +47,7 @@ let mutable monoArguments = ""
 /// Modifies the ProcessStartInfo according to the platform semantics
 let platformInfoAction (psi : ProcessStartInfo) = 
     if isMono && psi.FileName.EndsWith ".exe" then 
-        psi.Arguments <- monoArguments + " " + psi.FileName + " " + psi.Arguments
+        psi.Arguments <- monoArguments + " \"" + psi.FileName + "\" " + psi.Arguments
         psi.FileName <- monoPath
 
 


### PR DESCRIPTION

In ProcessHelper.platformInAction, psi.FileName needs to be surrounded in quotes so that if the filename of the exe has a space in it, the call to "mono <filename>" does not fail.

Simply surrounded psi.FileName with double quotes, which should handle all special characters and whitespace.