### PR TITLE
Fixing wrong paths for websharper targets file

### DIFF
--- a/websharperserverclient/ApplicationName.fsproj
+++ b/websharperserverclient/ApplicationName.fsproj
@@ -162,7 +162,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\WebSharper\build\WebSharper.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\WebSharper\build\WebSharper.targets'))" />
+    <Error Condition="!Exists('..\..\packages\WebSharper\build\WebSharper.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\WebSharper\build\WebSharper.targets'))" />
   </Target>
   <ProjectExtensions>
     <VisualStudio>

--- a/websharperserverclient/ApplicationName.fsproj
+++ b/websharperserverclient/ApplicationName.fsproj
@@ -157,12 +157,12 @@
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
-  <Import Project="..\packages\WebSharper\build\WebSharper.targets" Condition="Exists('..\packages\WebSharper\build\WebSharper.targets')" />
+  <Import Project="<%= packagesPath %>\WebSharper\build\WebSharper.targets" Condition="Exists('<%= packagesPath %>\WebSharper\build\WebSharper.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\WebSharper\build\WebSharper.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\WebSharper\build\WebSharper.targets'))" />
+    <Error Condition="!Exists('<%= packagesPath %>\WebSharper\build\WebSharper.targets')" Text="$([System.String]::Format('$(ErrorText)', '<%= packagesPath %>\WebSharper\build\WebSharper.targets'))" />
   </Target>
   <ProjectExtensions>
     <VisualStudio>

--- a/websharperspa/ApplicationName.fsproj
+++ b/websharperspa/ApplicationName.fsproj
@@ -132,12 +132,12 @@
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
-  <Import Project="..\packages\WebSharper\build\WebSharper.targets" Condition="Exists('..\packages\WebSharper\build\WebSharper.targets')" />
+  <Import Project="<%= packagesPath %>\WebSharper\build\WebSharper.targets" Condition="Exists('<%= packagesPath %>\WebSharper\build\WebSharper.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\WebSharper\build\WebSharper.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\WebSharper\build\WebSharper.targets'))" />
+    <Error Condition="!Exists('<%= packagesPath %>\WebSharper\build\WebSharper.targets')" Text="$([System.String]::Format('$(ErrorText)', '<%= packagesPath %>\WebSharper\build\WebSharper.targets'))" />
   </Target>
   <ProjectExtensions>
     <VisualStudio>

--- a/websharperspa/ApplicationName.fsproj
+++ b/websharperspa/ApplicationName.fsproj
@@ -137,7 +137,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\WebSharper\build\WebSharper.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\WebSharper\build\WebSharper.targets'))" />
+    <Error Condition="!Exists('..\..\packages\WebSharper\build\WebSharper.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\WebSharper\build\WebSharper.targets'))" />
   </Target>
   <ProjectExtensions>
     <VisualStudio>

--- a/websharpersuave/ApplicationName.fsproj
+++ b/websharpersuave/ApplicationName.fsproj
@@ -81,6 +81,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\WebSharper\build\WebSharper.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\WebSharper\build\WebSharper.targets'))" />
+    <Error Condition="!Exists('..\..\packages\WebSharper\build\WebSharper.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\WebSharper\build\WebSharper.targets'))" />
   </Target>
 </Project>

--- a/websharpersuave/ApplicationName.fsproj
+++ b/websharpersuave/ApplicationName.fsproj
@@ -76,11 +76,11 @@
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
-  <Import Project="..\packages\WebSharper\build\WebSharper.targets" Condition="Exists('..\packages\WebSharper\build\WebSharper.targets')" />
+  <Import Project="<%= packagesPath %>\WebSharper\build\WebSharper.targets" Condition="Exists('<%= packagesPath %>\WebSharper\build\WebSharper.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\WebSharper\build\WebSharper.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\WebSharper\build\WebSharper.targets'))" />
+    <Error Condition="!Exists('<%= packagesPath %>\WebSharper\build\WebSharper.targets')" Text="$([System.String]::Format('$(ErrorText)', '<%= packagesPath %>\WebSharper\build\WebSharper.targets'))" />
   </Target>
 </Project>


### PR DESCRIPTION
Websharper projects created with Forge did not build after bootstrapping due to wrong path to websharper.targets file in .fsproj